### PR TITLE
scons 3.0 compatibility fixes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -22,7 +22,7 @@ from subprocess import Popen, PIPE
 import coda
 
 # Created files & dirs will have this permission
-os.umask(002)
+os.umask(0o2)
 
 # Software version
 versionMajor = '4'
@@ -50,9 +50,9 @@ env = Environment(ENV = {'PATH' : os.environ['PATH']})
 # a configure-type test.
 is64bits = coda.is64BitMachine(env, platform, machine)
 if is64bits:
-    print "We're on a 64-bit machine"
+    print ("We're on a 64-bit machine")
 else:
-    print "We're on a 32-bit machine"
+    print ("We're on a 32-bit machine")
 
 
 #############################################
@@ -65,25 +65,25 @@ Help('\nlocal scons OPTIONS:\n')
 # debug option
 AddOption('--dbg', dest='ddebug', default=False, action='store_true')
 debug = GetOption('ddebug')
-if debug: print "Enable debugging"
+if debug: print ("Enable debugging")
 Help('--dbg               compile with debug flag\n')
 
 # vxworks 5.5 option
 AddOption('--vx5.5', dest='doVX55', default=False, action='store_true')
 useVxworks55 = GetOption('doVX55')
-if useVxworks55: print "Use vxWorks version 5.5"
+if useVxworks55: print ("Use vxWorks version 5.5")
 Help('--vx5.5             cross compile for vxworks 5.5\n')
 
 # vxworks 6.0 option
 AddOption('--vx6.0', dest='doVX60', default=False, action='store_true')
 useVxworks60 = GetOption('doVX60')
-if useVxworks60: print "Use vxWorks version 6.0"
+if useVxworks60: print ("Use vxWorks version 6.0")
 Help('--vx6.0             cross compile for vxworks 6.0\n')
 
 # 32 bit option
 AddOption('--32bits', dest='use32bits', default=False, action='store_true')
 use32bits = GetOption('use32bits')
-if use32bits: print "use 32-bit libs & executables even on 64 bit system"
+if use32bits: print ("use 32-bit libs & executables even on 64 bit system")
 Help('--32bits            compile 32bit libs & executables on 64bit system\n')
 
 # install directory option
@@ -153,7 +153,7 @@ if useVxworks:
     osname = 'vxworks'+ str(vxVersion) + '-ppc'
 
     if not coda.configureVxworks(env, vxVersion, platform):
-        print '\nCannot set enviroment for vxWorks ' + str(vxVersion) + ', exiting\n'
+        print ('\nCannot set enviroment for vxWorks ' + str(vxVersion) + ', exiting\n')
         Exit(0)
 
 else:
@@ -175,7 +175,7 @@ else:
 if is64bits and use32bits and not useVxworks:
     osname = osname + '-32'
 
-print "OSNAME =", osname
+print ("OSNAME = "+osname)
 
 # hidden sub directory into which variant builds go
 archDir = '.' + osname + debugSuffix
@@ -212,13 +212,13 @@ if 'install' in COMMAND_LINE_TARGETS:
     # Create the include directories (make symbolic link if possible)
     coda.makeIncludeDirs(incInstallDir, archIncInstallDir, osDir, archIncLocalLink)
 
-    print 'Main install dir  = ', mainInstallDir
-    print 'bin  install dir  = ', binInstallDir
-    print 'lib  install dir  = ', libInstallDir
-    print 'inc  install dirs = ', incInstallDir, ", ", archIncInstallDir
+    print ('Main install dir  = '+mainInstallDir)
+    print ('bin  install dir  = '+binInstallDir)
+    print ('lib  install dir  = '+libInstallDir)
+    print ('inc  install dirs = '+incInstallDir+", "+archIncInstallDir)
 
 else:
-    print 'No installation being done'
+    print ('No installation being done')
 
 print
 
@@ -253,7 +253,7 @@ Help('undoc               remove javadoc (in ./doc)\n')
 
 if 'tar' in COMMAND_LINE_TARGETS:
     if platform == 'SunOS':
-        print '\nMake tar file from Linux or MacOS please\n'
+        print ('\nMake tar file from Linux or MacOS please\n')
         Exit(0)
     coda.generateTarFile(env, 'evio', versionMajor, versionMinor)
 

--- a/coda.py
+++ b/coda.py
@@ -101,7 +101,7 @@ def is64BitMachine(env, platform, machine):
         ret = conf.CheckBits(ccflags)
         env = conf.Finish()
         if ret < 1:
-            print 'Cannot run test, assume 64 bit system'
+            print ('Cannot run test, assume 64 bit system')
             return True
         elif ret == 64:
             # Test shows 64 bit system'
@@ -163,7 +163,7 @@ def configureVxworks(env, vxVersion, platform):
                   '/site/vxworks/6.0/ppc/vxworks-6.0/target/h/wrn/coreip']
         env.Append(CPPDEFINES = ['VXWORKS_6'])
     else:
-        print 'Unknown version of vxWorks, exiting'
+        print ('Unknown version of vxWorks, exiting')
         return 0
 
 
@@ -174,14 +174,14 @@ def configureVxworks(env, vxVersion, platform):
             vxbin = vxbase + '/x86-linux2/bin/'
     elif platform == 'SunOS':
         if vxVersion >= 6:
-            print '\nVxworks 6.x compilation not allowed on solaris'
+            print ('\nVxworks 6.x compilation not allowed on solaris')
             return 0
         vxbin = vxbase + '/host/sun4-solaris2/bin/'
         if machine == 'i86pc':
-            print '\nVxworks compilation not allowed on x86 solaris'
+            print ('\nVxworks compilation not allowed on x86 solaris')
             return 0
     else:
-        print '\nVxworks compilation not allowed on ' + platform
+        print ('\nVxworks compilation not allowed on ' + platform)
         return 0
         
                     
@@ -229,8 +229,8 @@ def getInstallationDirs(osname, prefix, incdir, libdir, bindir):
         # prefix not defined try CODA env var
         if codaHomeEnv == "":
             if (incdir == None) or (libdir == None) or (bindir == None):
-                print "\nNeed to define CODA, or use the --prefix option,"
-                print "or all the --incdir, --libdir, and --bindir options.\n"
+                print ("\nNeed to define CODA, or use the --prefix option,")
+                print ("or all the --incdir, --libdir, and --bindir options.\n")
                 raise SystemExit
         else:
             prefix = codaHomeEnv
@@ -279,7 +279,7 @@ def makeIncludeDirs(includeDir, archIncludeDir, archDir, archIncLocalLink):
     # Make sure it's a directory (if we didn't create it)
     elif not os.path.isdir(includeDir):
         print
-        print "Error:", includeDir, "is NOT a directory"
+        print ("Error:", includeDir, "is NOT a directory")
         print
         raise SystemExit
 
@@ -297,7 +297,7 @@ def makeIncludeDirs(includeDir, archIncludeDir, archDir, archIncLocalLink):
             return
     elif not os.path.isdir(archDir):
         print
-        print "Error:", archDir, "is NOT a directory"
+        print ("Error:", archDir, "is NOT a directory")
         print
         raise SystemExit
 
@@ -308,17 +308,17 @@ def makeIncludeDirs(includeDir, archIncludeDir, archDir, archIncLocalLink):
     if not os.path.exists(archIncludeDir):
         # Create symbolic link: symlink(source, linkname)
         try:
-    	    if (archIncLocalLink == None) or (archIncLocalLink == ''):
-	    	symlink(includeDir, archIncludeDir)
+            if (archIncLocalLink == None) or (archIncLocalLink == ''):
+                symlink(includeDir, archIncludeDir)
             else:
-	    	symlink(archIncLocalLink, archIncludeDir)
+                symlink(archIncLocalLink, archIncludeDir)
         except OSError:
             # Failed to create symbolic link, so
             # just make it a regular directory
             os.makedirs(archIncludeDir)
     elif not os.path.isdir(archIncludeDir):
         print
-        print "Error:", archIncludeDir, "is NOT a directory"
+        print ("Error:", archIncludeDir, "is NOT a directory")
         print
         raise SystemExit
 
@@ -342,18 +342,18 @@ def configureJNI(env):
             java_base = '/System/Library/Frameworks/JavaVM.framework'
         else:
             # Search for the java compiler
-            print "JAVA_HOME environment variable not set. Searching for javac to find jni.h ..."
+            print ("JAVA_HOME environment variable not set. Searching for javac to find jni.h ...")
             if not env.get('JAVAC'):
-                print "The Java compiler must be installed and in the current path, exiting"
+                print ("The Java compiler must be installed and in the current path, exiting")
                 return 0
             jcdir = os.path.dirname(env.WhereIs('javac'))
             if not jcdir:
-                print "   not found, exiting"
+                print ("   not found, exiting")
                 return 0
             # assuming the compiler found is in some directory like
             # /usr/jdkX.X/bin/javac, java's home directory is /usr/jdkX.X
             java_base = os.path.join(jcdir, "..")
-            print "  found, dir = " + java_base        
+            print ("  found, dir = " + java_base)
         
     if sys.platform == 'darwin':
         # Apple does not use Sun's naming convention


### PR DESCRIPTION
  scons 3.0 uses python3.  Python 3 doesn't like some things.
  1.  print statements without stuff being printed in parens
  2.  The old octal number format (Use 0o prefix instead of 0)
  3.  Tab characters in the indentation.

If these changes workout for us, I will submit the patch to the upstream.